### PR TITLE
feat: API 문서화를 위한 swagger 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	// implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	// implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/moa/back/config/OpenApiConfig.java
+++ b/src/main/java/com/moa/back/config/OpenApiConfig.java
@@ -1,0 +1,31 @@
+package com.moa.back.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class OpenApiConfig {
+
+	@Bean
+	public OpenAPI openAPI() {
+		return new OpenAPI()
+			.info(new Info()
+				.title("MOA Backend API")
+				.description("Shared household finance app MOAs RESTful backend API")
+				.version("0.0.1-SNAPSHOT")
+				.contact(new Contact()
+					.name("MOA Team")
+					.email("contact@moa.com")))
+			.servers(List.of(
+				new Server().url("http://localhost:8080").description("Local Server"),
+				new Server().url("https://api.moa.com").description("Production Server")
+			));
+	}
+}
+

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,14 @@
 spring:
   application:
     name: MOA-Back
+
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
+  group-configs:
+    - group: 'default'
+      paths-to-match: '/api/**'


### PR DESCRIPTION
## 체크리스트

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## 변경 사항

- SpringDoc OpenAPI 의존성 추가
- Swagger UI 설정 (/swagger-ui.html)
- OpenApiConfig 설정 클래스 추가
- /api/** 엔드포인트 문서화 설정

Swagger UI: http://localhost:8080/swagger-ui.html
OpenAPI JSON: http://localhost:8080/api-docs

<img width="594" height="477" alt="image" src="https://github.com/user-attachments/assets/f3178a6c-77b8-4a60-928f-3fbac8964fdd" />

---

## 관련 이슈

- Closes #1 

---

## 추가 사항